### PR TITLE
docs: plan admin UI

### DIFF
--- a/features.md
+++ b/features.md
@@ -18,4 +18,35 @@ This document outlines the existing and planned features for MCPForge.
 
 ## Planned Features
 
-There are currently no planned features. This section will be updated as new features are planned.
+### Web-Based Tool Management Interface
+
+**Goal:** Provide a browser-accessible interface to interact with MCPForge and manage tools without using command-line requests.
+
+**Key Capabilities:**
+
+- Create new tools by submitting a Python snippet that is ingested and registered on the server.
+- Display a list of currently registered tool modules and allow their removal.
+- Show server health status and configuration details.
+
+**Implementation Plan:**
+
+1. **Add web framework and templating support.**
+   - Introduce a small FastAPI application served alongside the existing FastMCP server.
+   - Use Jinja2 templates to render pages containing forms and lists.
+2. **Expose REST endpoints wrapping existing admin tools.**
+   - `POST /tools` → wraps `collector.ingest_python` to create new tools.
+   - `GET /tools` → wraps `collector.list` to show registered modules.
+   - `DELETE /tools/{module}` → wraps `collector.remove` to delete a module.
+   - `GET /health` → calls `forge_health`.
+3. **Client-side interaction.**
+   - Use simple JavaScript or HTMX to submit forms asynchronously and update the page without reloads.
+4. **Server integration.**
+   - Serve the FastAPI app with Uvicorn on the same host/port configuration as the MCP server.
+   - Optionally use HTTPX internally if the web app communicates with the MCP server over HTTP.
+
+**Required Packages:** `fastapi`, `uvicorn`, `jinja2`, `httpx`
+
+**Open Questions / Next Steps:**
+
+- Decide on authentication/authorization for administrative access.
+- Determine whether to bundle static assets or rely on CDN links.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,9 @@ fastmcp>=2.9.1
 openai>=1.0.0
 pytest
 pytest-asyncio
+
+# Dependencies for planned web-based admin interface
+fastapi
+uvicorn
+jinja2
+httpx


### PR DESCRIPTION
## Summary
- outline a web-based interface for creating and managing MCPForge tools
- add FastAPI, Uvicorn, Jinja2, and HTTPX to requirements for the upcoming UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7f526d498832c94f6934bbb2124d5