### PR TITLE
docs: add development and testing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,49 +21,10 @@ dynamically registers new tools on the fly.
 - Web-based management UI and REST endpoints for creating, listing, and
   removing tools.
 
-## Requirements
+## Documentation
 
-- Python 3.8 or later.
-- An [OpenAI API key](https://platform.openai.com/account/api-keys) with
-  access to the `gpt-4.1-nano` model.  Set it in the environment variable
-  `OPENAI_API_KEY` before running.
-
-Install dependencies using pip:
-
-```bash
-python3 -m venv .venv && . .venv/bin/activate
-pip install -r requirements.txt
-export OPENAI_API_KEY=sk-...
-```
-
-## Running
-
-To start the server on the default host and port (127.0.0.1:8000):
-
-```bash
-python run.py
-```
-
-You can customise the host/port via environment variables:
-
-```bash
-HOST=0.0.0.0 PORT=8765 python run.py
-```
-
-The web interface and REST endpoints are served from the root URL. The MCP
-server is available on the `/sse` path for SSE clients.
-
-## Ingesting Code
-
-Use an MCP client (for example, Zed or `mcp-remote`) to call the `collector.ingest_python`
-tool.  Provide two arguments:
-
-- `snippet_name`: a descriptive label for your snippet (used to name generated modules).
-- `code`: the raw Python code containing one or more functions.
-
-The server will call `gpt-4.1-nano` to decide which functions to expose as tools.
-If none are deemed safe/appropriate, the first function will be exposed by default.
-Newly registered tools become available immediately and are prefixed by the snippet name.
+- [Development guide](development.md)
+- [Testing guide](testing.md)
 
 ## License
 

--- a/development.md
+++ b/development.md
@@ -1,0 +1,32 @@
+# Development
+
+This guide describes how to set up MCPForge for local development.
+
+## Requirements
+
+- Python 3.11+
+- [virtualenv](https://docs.python.org/3/library/venv.html)
+
+## Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running the server
+
+Start the MCPForge server locally:
+
+```bash
+python run.py
+```
+
+The server listens on port 8000 by default.
+
+## Ingesting tools
+
+With the server running, send Python snippets via the `collector.ingest_python` tool.
+The selected functions will become new MCP tools available immediately.
+

--- a/testing.md
+++ b/testing.md
@@ -1,0 +1,22 @@
+# Testing
+
+This project uses [pytest](https://docs.pytest.org/) for automated tests.
+
+## Setup
+
+Create and activate a virtual environment, then install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running tests
+
+Run the full test suite:
+
+```bash
+pytest -q
+```
+


### PR DESCRIPTION
## Summary
- remove installation and usage instructions from the README, leaving only a feature overview and license information
- add dedicated development and testing guides with setup and usage details
- link new guides from the README

## Testing
- `python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements.txt` *(fails: Could not find a version that satisfies fastmcp due to 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a804f0e39c832c962aedb75481de78