### PR TITLE
Improve snippet ingestion with GPT-assisted cleanup

### DIFF
--- a/app/llm.py
+++ b/app/llm.py
@@ -80,3 +80,29 @@ def choose_tools_with_gpt(code: str, fn_summaries: List[Dict[str, Any]]) -> List
         return []
 
     return _call_openai()
+
+
+def rewrite_snippet_with_gpt(text: str) -> str:
+    """Rewrite an ambiguous snippet into valid Python code using GPT."""
+
+    def _call_openai() -> str:
+        import os
+        if os.getenv("USE_MOCK_LLM"):
+            # For tests, allow overriding the rewritten snippet
+            return os.getenv("MOCK_LLM_SNIPPET", text)
+        from openai import OpenAI
+        client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        system = (
+            "You transform incomplete or pseudo-code into a complete, valid "
+            "Python function snippet. Return only runnable Python code."
+        )
+        rsp = client.responses.create(
+            model="gpt-4.1-nano",
+            input=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": [{"type": "input_text", "text": text}]},
+            ],
+        )
+        return rsp.output_text
+
+    return _call_openai()

--- a/architecture.md
+++ b/architecture.md
@@ -53,7 +53,7 @@ MCPForge is a tool-collector server built with the Model Context Protocol and Fa
 ## Documentation
 - Additional guides: `development.md`, `testing.md`, `usage-mcp.md`, and `usage-ui.md` describe setup, testing, and usage from MCP clients or the web interface.
 
-## Changes to Implement
-- **Detect LLM-formatted submissions:** When a user paste includes narrative text followed by a fenced code block (e.g., Markdown ````python` fences), strip the fences and use only the code segment.
-- **Accept clean snippets:** If the provided text parses successfully with the `ast` module, treat it as ready-to-use code and proceed with normal ingestion.
-- **Delegate ambiguous input to GPT-4.1-nano:** For any other cases—such as incomplete or pseudocode snippets—invoke `gpt-4.1-nano` with AST helpers to reconstruct the function or tool before registration.
+## User Input Ingestion
+- **Detect LLM-formatted submissions:** When a user paste includes narrative text followed by a fenced code block (e.g., Markdown ```python fences), the server strips the fences and uses only the code segment.
+- **Accept clean snippets:** If the resulting text parses successfully with the `ast` module, the snippet is treated as ready-to-use code and normal ingestion proceeds.
+- **Delegate ambiguous input to GPT-4.1-nano:** For any other cases—such as incomplete or pseudocode snippets—the server invokes `gpt-4.1-nano` to rewrite the snippet into valid Python before attempting registration.


### PR DESCRIPTION
## Summary
- normalize user submissions: strip fenced code blocks, accept valid AST, and rewrite ambiguous snippets with GPT-4.1-nano
- document the new ingestion pipeline in `architecture.md`
- test fenced snippets and GPT-driven reconstruction paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87edd3240832ca31e4d3a2a57e6e6