### PR TITLE
Enhance MCPForge Web UI and htmx integration

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -223,7 +223,7 @@ def build_app():
         return mcp.list_collected()
 
     @app.post("/tools", status_code=201)
-    async def web_create_tool(request: Request) -> JSONResponse:
+    async def web_create_tool(request: Request):
         if request.headers.get("content-type", "").startswith("application/json"):
             data = await request.json()
         else:
@@ -237,11 +237,24 @@ def build_app():
             os.environ["USE_MOCK_LLM"] = "1"
         result = mcp.ingest_snippet(snippet_name, code)
         status = 201 if result.get("created") else 400
+        tools = mcp.list_collected()
+        if request.headers.get("hx-request"):
+            headers = {"HX-Trigger": "toolAdded" if status == 201 else "toolError"}
+            return templates.TemplateResponse(
+                "tools.html", {"request": request, "tools": tools},
+                status_code=status, headers=headers
+            )
         return JSONResponse(result, status_code=status)
 
     @app.delete("/tools/{module}")
-    async def web_remove_tool(module: str) -> dict[str, bool]:
+    async def web_remove_tool(module: str, request: Request):
         ok = mcp.remove_collected(module)
+        tools = mcp.list_collected()
+        if request.headers.get("hx-request"):
+            headers = {"HX-Trigger": "toolRemoved" if ok else "toolError"}
+            return templates.TemplateResponse(
+                "tools.html", {"request": request, "tools": tools}, headers=headers
+            )
         return {"removed": ok}
 
     @app.get("/", response_class=HTMLResponse)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,24 +4,47 @@
   <meta charset="utf-8" />
   <title>MCPForge</title>
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    .container { max-width: 800px; margin: auto; }
+    form { margin-bottom: 1rem; }
+    .field { margin-bottom: 0.5rem; }
+    label { display: block; font-weight: bold; margin-bottom: 0.25rem; }
+    input[type="text"], textarea { width: 100%; padding: 0.5rem; }
+    button { padding: 0.5rem 1rem; margin-top: 0.5rem; }
+    .tool-list { list-style: none; padding: 0; }
+    .tool-item { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0; border-bottom: 1px solid #ddd; }
+    .message { margin-top: 1rem; min-height: 1.2em; }
+  </style>
 </head>
 <body>
-  <h1>MCPForge Tool Manager</h1>
-  <form hx-post="/tools" hx-target="#tools" hx-swap="outerHTML">
-    <label>Snippet Name <input type="text" name="snippet_name"/></label><br/>
-    <label>Code Snippet<br/>
-      <textarea name="code" rows="6" cols="60"></textarea>
-    </label><br/>
-    <button type="submit">Ingest</button>
-  </form>
-  <h2>Registered Modules</h2>
-  <ul id="tools">
-    {% for mod in tools %}
-    <li>
-      {{ mod }}
-      <button hx-delete="/tools/{{ mod }}" hx-target="#tools" hx-swap="outerHTML">Remove</button>
-    </li>
-    {% endfor %}
-  </ul>
+  <div class="container">
+    <h1>MCPForge Tool Manager</h1>
+    <form hx-post="/tools" hx-target="#tools" hx-swap="outerHTML">
+      <div class="field">
+        <label for="snippet_name">Snippet Name</label>
+        <input id="snippet_name" type="text" name="snippet_name" required />
+      </div>
+      <div class="field">
+        <label for="code">Code Snippet</label>
+        <textarea id="code" name="code" rows="6" cols="60" required></textarea>
+      </div>
+      <button type="submit">Ingest</button>
+    </form>
+    <div id="message" class="message"></div>
+    <h2>Registered Modules</h2>
+    {% include 'tools.html' %}
+  </div>
+  <script>
+    document.body.addEventListener('toolAdded', function() {
+      document.getElementById('message').textContent = 'Tool added successfully';
+    });
+    document.body.addEventListener('toolRemoved', function() {
+      document.getElementById('message').textContent = 'Tool removed';
+    });
+    document.body.addEventListener('toolError', function() {
+      document.getElementById('message').textContent = 'Operation failed';
+    });
+  </script>
 </body>
 </html>

--- a/app/templates/tools.html
+++ b/app/templates/tools.html
@@ -1,0 +1,13 @@
+<ul id="tools" class="tool-list">
+  {% for mod in tools %}
+  <li class="tool-item">
+    <span class="tool-name">{{ mod }}</span>
+    <button 
+      class="remove-button"
+      hx-delete="/tools/{{ mod }}"
+      hx-target="#tools"
+      hx-swap="outerHTML"
+      hx-confirm="Remove {{ mod }}?">Remove</button>
+  </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- Style the HTML interface and add accessible form fields
- Add template for tool list with delete confirmation
- Return HTML snippets with HX-Trigger headers for htmx updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2cc76f4832c8ef1ff95228b4821